### PR TITLE
Rename setable vars to contain role name as prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ The only mandatory variable is `ubuntu_pro_token`.
 | `ubuntu_pro_config.metering_timer`         | Metering Timer                   | Int    | NO        | `14400`       |
 | `ubuntu_pro_enabled_services`              | List of pro services to enable   | List   | NO        | in defaults.yml|
 | `ubuntu_pro_disabled_services`             | List of pro services to disable   | List   | NO        | in defaults.yml|
+| `ubuntu_pro_pkgs_state`                    | State of required packages       | String | NO        | present |
+
 
 You can find more information about `ubuntu_pro_config.*` variables on [Ubuntu Pro Client README](https://github.com/canonical/ubuntu-advantage-client#readme).
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ The only mandatory variable is `ubuntu_pro_token`.
 | `ubuntu_pro_enabled_services`              | List of pro services to enable   | List   | NO        | in defaults.yml|
 | `ubuntu_pro_disabled_services`             | List of pro services to disable   | List   | NO        | in defaults.yml|
 | `ubuntu_pro_pkgs_state`                    | State of required packages       | String | NO        | present |
+| `ubuntu_pro_debug`                         | Set debug on to print output       | Bool | NO        | false |
 
 
 You can find more information about `ubuntu_pro_config.*` variables on [Ubuntu Pro Client README](https://github.com/canonical/ubuntu-advantage-client#readme).

--- a/README.md
+++ b/README.md
@@ -27,8 +27,12 @@ The only mandatory variable is `ubuntu_pro_token`.
 | `ubuntu_pro_config.update_messaging_timer` | Update Messaging Timer           | Int    | NO        | `21600`       |
 | `ubuntu_pro_config.update_status_timer`    | Update Status Timer              | Int    | NO        | `43200`       |
 | `ubuntu_pro_config.metering_timer`         | Metering Timer                   | Int    | NO        | `14400`       |
+| `ubuntu_pro_config.metering_timer`         | Metering Timer                   | Int    | NO        | `14400`       |
+| `ubuntu_pro_enabled_services`              | List of pro services to enable   | List   | NO        | in defaults.yml|
+| `ubuntu_pro_disabled_services`             | List of pro services to disable   | List   | NO        | in defaults.yml|
 
 You can find more information about `ubuntu_pro_config.*` variables on [Ubuntu Pro Client README](https://github.com/canonical/ubuntu-advantage-client#readme).
+
 
 ## Dependencies
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,3 +14,5 @@ ubuntu_pro_enabled_services:
 # To disable a pro service, remote it from ubuntu_pro_enabled_services and add
 # it to ubuntu_pro_disabled_services
 ubuntu_pro_disabled_services: []
+
+ubuntu_pro_pkgs_state: present

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-debug: false
+ubuntu_pro_debug: false
 ubuntu_pro_state: present # possible values defined in meta/argument_specs.yml
 
 # To enable certain pro services define the values in this list

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,16 @@
 ---
 debug: false
-state: present # possible values defined in meta/argument_specs.yml
+ubuntu_pro_state: present # possible values defined in meta/argument_specs.yml
+
+# To enable certain pro services define the values in this list
+ubuntu_pro_enabled_services:
+  - 'cc-eal'       # Common Criteria EAL2
+  - 'esm-infra'    # Expanded Security Maintenance for Infrastructure
+  - 'fips'
+  - 'fips-updates'
+  - 'livepatch'    # Canonical Kernel Livepatch
+  - 'usg'
+
+# To disable a pro service, remote it from ubuntu_pro_enabled_services and add
+# it to ubuntu_pro_disabled_services
+ubuntu_pro_disabled_services: []

--- a/meta/argument_specs.yml
+++ b/meta/argument_specs.yml
@@ -10,7 +10,7 @@ argument_specs:
         description: Use debug module to display 'pro' command stdout/stderr
         type: bool
         default: false
-      disabled_services:
+      ubuntu_pro_disabled_services:
         description: List of services to disable
         type: list
         elements: str
@@ -21,7 +21,7 @@ argument_specs:
           - 'fips-updates'
           - 'livepatch'    # Canonical Kernel Livepatch
           - 'usg'
-      enabled_services:
+      ubuntu_pro_enabled_services:
         description: List of services to enable
         type: list
         elements: str
@@ -32,7 +32,7 @@ argument_specs:
           - 'fips-updates'
           - 'livepatch'    # Canonical Kernel Livepatch
           - 'usg'
-      state:
+      ubuntu_pro_state:
         description: State of Ubuntu Pro installation
         type: str
         choices:

--- a/meta/argument_specs.yml
+++ b/meta/argument_specs.yml
@@ -6,7 +6,7 @@ argument_specs:
       - The main entry point just combines the repositories and packages
              entry points.
     options:
-      debug:
+      ubuntu_pro_debug:
         description: Use debug module to display 'pro' command stdout/stderr
         type: bool
         default: false

--- a/tasks/disable_services.yml
+++ b/tasks/disable_services.yml
@@ -4,7 +4,7 @@
   become: yes
   register: reg_pro_disable
   when: item in ubuntu_pro_services
-  loop: "{{ disabled_services }}"
+  loop: "{{ ubuntu_pro_disabled_services }}"
   changed_when: reg_pro_disable.rc == 0
   failed_when:
     - reg_pro_disable.rc != 0

--- a/tasks/enable_services.yml
+++ b/tasks/enable_services.yml
@@ -4,7 +4,7 @@
   become: yes
   register: reg_pro_enable
   when: item in ubuntu_pro_services
-  loop: "{{ enabled_services }}"
+  loop: "{{ ubuntu_pro_enabled_services }}"
   changed_when: reg_pro_enable.rc == 0
   failed_when:
     - reg_pro_enable.rc != 0

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,32 +1,32 @@
 ---
 - name: Include tasks 'validate_ubuntu_lts_version.yml'
   include_tasks: validate_ubuntu_lts_version.yml
-  when: state == 'present' or state == 'attached'
+  when: ubuntu_pro_state == 'present' or ubuntu_pro_state == 'attached'
 
 - name: Include tasks 'requirements.yml'
   include_tasks: requirements.yml
-  when: state == 'present' or state == 'attached'
+  when: ubuntu_pro_state == 'present' or ubuntu_pro_state == 'attached'
 
 - name: Include tasks 'configure.yml'
   include_tasks: configure.yml
-  when: state == 'present' or state == 'attached'
+  when: ubuntu_pro_state == 'present' or ubuntu_pro_state == 'attached'
 
 - name: Include tasks 'register.yml'
   include_tasks: register.yml
-  when: state == 'present' or state == 'attached'
+  when: ubuntu_pro_state == 'present' or ubuntu_pro_state == 'attached'
 
 - name: Include tasks 'enable_services.yml'
   include_tasks: enable_services.yml
-  when: enabled_services is defined and (state == 'present' or state == 'attached')
+  when: ubuntu_pro_enabled_services is defined and (ubuntu_pro_state == 'present' or ubuntu_pro_state == 'attached')
 
 - name: Include tasks 'disable_services.yml'
   include_tasks: disable_services.yml
-  when: disabled_services is defined and (state == 'present' or state == 'attached')
+  when: ubuntu_pro_disabled_services is defined and (ubuntu_pro_state == 'present' or ubuntu_pro_state == 'attached')
 
 - name: Include tasks 'unregister.yml'
   include_tasks: unregister.yml
-  when: state == 'absent' or state == 'detached'
+  when: ubuntu_pro_state == 'absent' or ubuntu_pro_state == 'detached'
 
 - name: Include tasks 'uninstall.yml'
   include_tasks: uninstall.yml
-  when: state == 'absent'
+  when: ubuntu_pro_state == 'absent'

--- a/tasks/register.yml
+++ b/tasks/register.yml
@@ -9,4 +9,4 @@
 - name: Print 'pro attach' command output
   ansible.builtin.debug:
     var: reg_pro_attach
-  when: debug
+  when: ubuntu_pro_debug

--- a/tasks/requirements.yml
+++ b/tasks/requirements.yml
@@ -12,5 +12,5 @@
 - name: Install 'ubuntu-advantage-tools' package
   ansible.builtin.apt:
     name: ubuntu-advantage-tools
-    state: latest
+    state: "{{ netplan_pkgs_pkgs_state | default('present') }}"
   become: yes

--- a/tasks/requirements.yml
+++ b/tasks/requirements.yml
@@ -12,5 +12,5 @@
 - name: Install 'ubuntu-advantage-tools' package
   ansible.builtin.apt:
     name: ubuntu-advantage-tools
-    state: "{{ netplan_pkgs_pkgs_state | default('present') }}"
+    state: "{{ ubuntu_pro_pkgs_state | default('present') }}"
   become: yes

--- a/tasks/unregister.yml
+++ b/tasks/unregister.yml
@@ -19,4 +19,4 @@
 - name: Print 'pro detach' command output
   ansible.builtin.debug:
     var: reg_pro_detach
-  when: (debug and pro_command_exists)
+  when: (ubuntu_pro_debug and pro_command_exists)


### PR DESCRIPTION
Hey @pescobar I have renamed the variables that are user setable to contain the role name as prefix `ubuntu_pro_` so that we don't run into issues with `enabled_services` and `disabled_services`.

